### PR TITLE
Invalid return value in FlashHelper

### DIFF
--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -34,7 +34,7 @@ class FlashHelper extends \Cake\View\Helper\FlashHelper {
      */
     public function render($key = 'flash', array $options = []): ?string {
         if (!$this->getView()->getRequest()->getSession()->check("Flash.$key")) {
-            return;
+            return null;
         }
 
         $flash = $this->getView()->getRequest()->getSession()->read("Flash.$key");


### PR DESCRIPTION
Fixes #5 :
```
PHP Fatal error:  A function with return type must return a value (did you mean "return null;" instead of "return;"?) in ./vendor/holt59/cakephp4-bootstrap-helpers/src/View/Helper/FlashHelper.php on line 37
```